### PR TITLE
Fix pug build error

### DIFF
--- a/.htmlnanorc
+++ b/.htmlnanorc
@@ -1,0 +1,3 @@
+{
+  "minifySvg": false
+}


### PR DESCRIPTION
Disable `minifySvg` in htmlnano configuration.

The build was failing with `tree.render is not a function` due to an incompatibility between `htmlnano` and `svgo` when attempting to minify SVG elements. Disabling this specific module resolves the build error.

---
<a href="https://cursor.com/background-agent?bcId=bc-adc6529b-e81d-4c94-908a-af36ca9c174e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-adc6529b-e81d-4c94-908a-af36ca9c174e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add `.htmlnanorc` to disable `minifySvg` in htmlnano, preventing SVG minification during builds.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c42ed8947e8f455406574a548244c28983c541fe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->